### PR TITLE
Allow driver-class-name in node config

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ Also appropriate `jdbc driver` and `groovy-sql-<version>.jar` (tested with groov
 
 To configure connect to you database add following parameters to node description in Rundeck Project resourses.xml:
 
-`db-type` : Database type. ORACLE and MYSQL was tested. See `com.github.strdn.rundeck.plugin.jdbcexecutor.DBTypes` for full list of supported databases
+One of:
+  * `db-type` : Database type. ORACLE and MYSQL was tested. See `com.github.strdn.rundeck.plugin.jdbcexecutor.DBTypes` for full list of supported databases
+  * `driver-class-name`: The fully-qualified name of the driver class. If provided, `db-type` is ignored.
 
 `jdbc-connect` : jdbc connection string
  


### PR DESCRIPTION
This PR will allow a database driver class name to be specified in the node configuration. It allows users to use a driver that falls outside of the list of convenience database in `db-type`. If provided, the class name overrides `db-type`.

I also updated the documentation to explain this.

Thanks!